### PR TITLE
WIP: Add docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml

--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,59 @@
+# GOV.UK Forms Development
+
+This is a guide to getting the Gov.uk Forms development environment up and running.
+
+list of github projects.
+
+This repo lives at:
+https://github.com/alphagov/forms
+
+The express base prototype can be found at:
+https://github.com/alphagov/forms-prototypes
+
+and the static page which is behind https://www.forms.service.gov.uk/ can be found at:
+https://github.com/alphagov/forms-product-page
+
+
+The components which make up the service are:
+https://github.com/alphagov/forms-runner
+https://github.com/alphagov/forms-api
+https://github.com/alphagov/forms-admin
+
+## Commands for running the whole thing in docker.
+
+You need to check out all three projects in the parent directory of this repo.
+Your directory structure should look like this:
+
+```
+top-level/
+├── forms-admin
+├── forms-api
+└── forms-runner
+└── forms
+    └── development
+        ├── README.md
+        └── docker-compose.yml
+```
+
+Then run:
+```bash
+docker-compose up
+```
+
+Wait a while as the images are downloaded and built. Eventually you should see the screen fill with logging information as the postgres, redis and the forms services start.
+
+You should be able to open the admin interface on http://localhost:3000 , and the runner on http://localhost:3001
+
+To stop the services from running, press `Ctrl-c` and then enter:
+```bash
+docker-compose stop
+```
+
+If you make changes to the docker file:
+
+```bash
+docker-compose up --build
+```
+
+## The override file
+The override file shows an example or running services locally in addition to those defined in the docker-compose.yml file.

--- a/development/docker-compose.override.yml.example
+++ b/development/docker-compose.override.yml.example
@@ -1,0 +1,39 @@
+version: "2.4"
+
+services:
+  # forms-asset-builder:
+  #   build:
+  #     context: "../../forms-runner"
+  #     target: "assets"
+  #     args:
+  #       - RAILS_ENV=development
+  #       - NODE_ENV=development
+  #   env_file:
+  #     - forms-runner/var.env
+  #   depends_on:
+  #     - redis
+  #   volumes:
+  #     - "../../forms-runner:/app:cached"
+  #   command: ["yarn", "dev"]
+
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    environment:
+      - REDIS_HOSTS=local:redis:6379
+    ports:
+      - 8081:8081
+    depends_on:
+      - redis
+
+  pgweb:
+    container_name: pgweb
+    restart: always
+    image: sosedoff/pgweb
+    ports:
+      - 8082:8081
+    links:
+      - postgres:postgres
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+    depends_on:
+      - postgres

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "2.4"
+
+services:
+  forms-admin:
+    build:
+      context: ../../forms-admin
+      args:
+        - RAILS_ENV=development
+        - NODE_ENV=development
+    env_file:
+      - forms-admin/var.env
+    volumes:
+      - "../../forms-admin:/app:cached"
+    tmpfs:
+      - /app/tmp/pids:mode=775,size=1k,uid=1000,gid=1000
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    ports:
+      - 3000:3000
+
+  forms-api:
+    build:
+      context: ../../forms-api
+    env_file:
+      - forms-api/var.env
+    volumes:
+      - "../../forms-api:/app:cached"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - 9292:3000
+
+  forms-runner:
+    build:
+      context: "../../forms-runner"
+      args:
+        - RAILS_ENV=development
+        - NODE_ENV=development
+    env_file:
+      - forms-runner/var.env
+    depends_on:
+      redis:
+        condition: service_started
+    tmpfs:
+      - /app/tmp/pids:mode=775,size=1k,uid=1000,gid=1000
+    ports:
+      - 3001:3000
+    volumes:
+      - "../../forms-runner:/app:cached"
+
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres:/var/lib/postgresql/data
+      - ./postgres/initdb.d:/docker-entrypoint-initdb.d/
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  redis-data:
+  postgres:

--- a/development/forms-admin/var.env
+++ b/development/forms-admin/var.env
@@ -1,0 +1,12 @@
+RAILS_ENV=development
+RACK_ENV=development
+API_BASE=http://forms-api:3000
+SECRET_KEY_BASE=assets
+RAILS_SERVE_STATIC_FILES=1
+GDS_SSO_OAUTH_ID=example.org
+GDS_SSO_OAUTH_SECRET=secret
+GOVUK_APP_DOMAIN=example.org
+GDS_SSO_STRATEGY=mock
+# NOTIFY_API_KEY=((NOTIFY_API_KEY))
+DATABASE_URL=postgres://forms_admin:forms_admin@postgres/forms_admin
+RAILS_LOG_TO_STDOUT=1

--- a/development/forms-api/var.env
+++ b/development/forms-api/var.env
@@ -1,0 +1,2 @@
+RACK_ENV=development
+DATABASE_URL=postgres://forms_api:forms_api@postgres/forms_api

--- a/development/forms-runner/var.env
+++ b/development/forms-runner/var.env
@@ -1,0 +1,8 @@
+RAILS_ENV=development
+RACK_ENV=development
+NODE_ENV=development
+API_BASE=http://forms-api:3000
+SECRET_KEY_BASE=dummyvalue
+RAILS_SERVE_STATIC_FILES=1
+RAILS_LOG_TO_STDOUT=1
+# NOTIFY_API_KEY=((NOTIFY_API_KEY))

--- a/development/postgres/initdb.d/init.sql
+++ b/development/postgres/initdb.d/init.sql
@@ -1,0 +1,7 @@
+CREATE USER forms_admin WITH PASSWORD 'forms_admin' CREATEDB;
+CREATE DATABASE forms_admin;
+GRANT ALL PRIVILEGES ON DATABASE forms_admin TO forms_admin;
+
+CREATE USER forms_api WITH PASSWORD 'forms_api' CREATEDB;
+CREATE DATABASE forms_api;
+GRANT ALL PRIVILEGES ON DATABASE forms_api TO forms_api;


### PR DESCRIPTION
This commit adds a docker compose development environment for the 3
projects which make up the GOV.UK Forms service.

It's only intended for use in development, not production.

Notes:
 - uses version 2.4 because it's slightly better for development
 - uses Debian over Alpine, which is larger but perhaps has better
   support
 - exposes the individual service ports to the host
 - could use host.docker.internal in the var files to allow things like
   running the api natively while still using the other projects
   externally
 - single Dockerfile in the projects which defaults to being "production
   ready". The compose file overrides values for development

Need to:
- Add documentation
- Test on different OS/docker versions
- Add common commands/setup script (and Makefile)
- Add extra features

https://github.com/nickjj/docker-rails-example is a good source of inspiration for rails docker containers.


# PR Checklist

- [ ] If you are proposing a new decision record document, used the right template for that
      - ([ADR](https://github.com/alphagov/forms/blob/main/ADR/ADRXXX-architecture-decision-record-template.md), [decision-record](https://github.com/alphagov/forms/blob/main/decision-record/DRXXX-decision-record-template.md), engagement, [research](https://github.com/alphagov/forms/blob/main/research/YYYY-MM-DD-template.md))
- [ ] Set yourself as the Assignee
- [ ] Tag anyone you would like to review, or @forms-design or @forms-devs
- [ ] Fill in the template below


---

# What

Describe what you have changed and why.

# How to review

Describe the steps required to test the changes.

For example:

1. Semantic: Do you agree with the changes?
1. Syntactic: Spelling, grammar, etc.

# Who can review

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
