### PR TITLE
Update sequence diagrams for forms-admin PR #331

### DIFF
--- a/diagrams/sequence-diagrams/changing-a-form.md
+++ b/diagrams/sequence-diagrams/changing-a-form.md
@@ -49,10 +49,6 @@ sequenceDiagram
     browser->>admin: POST /forms/{form id}/make-live<br>payload: {forms_make_live_form"=><br>{"confirm_make_live"=>"made_live"},<br>"form_id"=>"{form id"}}
     admin->>api: POST /api/v1/forms/{form id}/make-live<br>payload: {includes all form attributes and values}<br>Controller Action doesn't use any
     note over admin,api: Creates a new record in published_forms table,<br>with a copy of the form and all its pages<br>
-    admin-->>browser: REDIRECT 302 
-    browser->>admin: GET /forms/{form id}/live-confirmation
-    admin->>api: GET /forms/{form id}
-    admin->>api: GET /forms/{form id}
     browser-->>user: show "Your form is live" confirmation page
     user->>browser: click "Continue to form details" link
     browser->>admin: GET /forms/{form id}/live

--- a/diagrams/sequence-diagrams/publishing-a-form.md
+++ b/diagrams/sequence-diagrams/publishing-a-form.md
@@ -25,10 +25,6 @@ sequenceDiagram
   admin->>api: GET /api/v1/forms/{form id}
   admin->>api: GET /api/v1/forms/{form id}/pages
   admin->>api: POST /api/v1/forms/{form id}/make-live<br>payload: {includes all form attributes and values}<br>Controller Action doesn't use any
-  admin-->>browser: REDIRECT 302
-  browser->>admin: GET /forms/{form id}/live-confirmation
-  admin->>api: GET /api/v1/forms/{form id}
-  admin->>api: GET /api/v1/forms/{form id}
   browser-->>user: show "Your form is live" page
   user->>user: Copy URL for the form
 


### PR DESCRIPTION
# What

Updates the sequence diagrams to include the changes from PR alphagov/forms-admin#331, which removes the `/forms/{form-id}/live-confirmation` endpoint and the redirect to that page in favour of immediately rendering the confirmation page.

# How to review

Take a look at the revised sequence diagram and check they make sense to you and match the changes in the PR above.

# Who can review

Anyone except me.