### PR TITLE
Move decision to top of template

### DIFF
--- a/ADR/ADRXXX-architecture-decision-record-template.md
+++ b/ADR/ADRXXX-architecture-decision-record-template.md
@@ -6,13 +6,13 @@ Date: YYYY-MM-DD
 
 > Proposed, Accepted, Rejected, Deprecated, Superseded by ADRzzz
 
-## Context
-
-> the facts behind the need to make the decision
-
 ## Decision
 
 > what the team has decided to do
+
+## Context
+
+> the facts behind the need to make the decision
 
 ## Consequences
 


### PR DESCRIPTION
# PR Checklist

- [x] Set yourself as the Assignee
- [x] Tag anyone you would like to review, or @forms-design or @forms-devs
- [x] Fill in the template below


---

# What

I've moved the 'Decision' section above 'Context' in the ADR template. The decision is the crucial piece of information in an ADR, the context and consequences are supporting information. This is also closer to the [original ADR proposal by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions), as referenced in the GDS Way. We briefly discussed this at today's technical catchup.



# How to review

Semantic: Do you agree with the changes?

# Who can review

Any Forms tech team member
