### PR TITLE
Remove duplicate requests between forms-admin and forms-api due to au…

### DIFF
--- a/diagrams/sequence-diagrams/changing-a-form.md
+++ b/diagrams/sequence-diagrams/changing-a-form.md
@@ -22,7 +22,6 @@ sequenceDiagram
   user->>browser: click "Create a draft to edit" button
   browser->>admin: GET /forms/{form id}
   admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}/pages
   browser-->>user: show draft form page with task list
   
@@ -31,16 +30,13 @@ sequenceDiagram
   user->>browser: click "Make your changes live" task
   browser->>admin: GET /forms/{form id}/make-live
   admin->>api: GET /api/v1/forms/{form id}
-  admin->>api: GET /api/v1/forms/{form id}
   browser-->>user: show "Make your changes live" page
   alt form creator decides not to make form live
     user->>browser: click "No" and submits page
     browser->>admin: POST /forms/{form id}/make-live<br>payload: {forms_make_live_form"=><br>{"confirm_make_live"=>"not_made_live"},<br>"form_id"=>"{form id"}}
     admin->>api: GET /api/v1/forms/{form id}
-    admin->>api: GET /api/v1/forms/{form id}
     admin-->>browser: REDIRECT 302
     browser->>admin: GET /forms/{form id}
-    admin->>api: GET /forms/{form id}
     admin->>api: GET /forms/{form id}
     admin->>api: GET /forms/{form id}/pages
     browser-->>user: show draft form page with task list

--- a/diagrams/sequence-diagrams/creating-a-form.md
+++ b/diagrams/sequence-diagrams/creating-a-form.md
@@ -23,8 +23,6 @@ sequenceDiagram
   admin-->>browser: 302
   browser->>admin: GET /forms/{form id}
   admin->>api: GET /forms/{form id}
-  admin->>admin: check user org matches form org
-  admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}/pages
   browser-->>user: show "Create a form" page
 ```
@@ -45,8 +43,6 @@ sequenceDiagram
 
   user->>browser: click "Add and edit your questions" link
   browser->>admin: GET /forms/1/pages/new/type-of-answer
-  admin->>api: GET /forms/{form id}
-  admin->>admin: check user org matches form org
   admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}/pages
 
@@ -94,18 +90,16 @@ sequenceDiagram
 
   user->>browser: click "Add a declaration for people to agree to" link
   browser->>admin: GET /forms/{form id}/declaration
-  admin->>api: GET /forms/{form id}
+
   admin->>api: GET /forms/{form id}
   browser-->>user: show "Add a declaration" page
   user->>browser: Provide declaration<br />click "Save and continue" button
   browser->>admin: POST /forms/{form id}/declaration
   admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   admin->>api: PUT /forms/{form id}
   api->>api: Update form
   admin-->>browser: 302
   browser->>admin: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}/pages
   browser-->>user: show "Create a form" page
@@ -137,7 +131,6 @@ sequenceDiagram
   user->>browser: click "Set the email address for completed forms" link
   browser->>admin: GET /forms/{form id}/submission-email
   admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   browser-->>user: show "Set the email address for completed forms" page
   user->>browser: Provide email address<br />click "Save and continue" button
   browser->>admin: POST /forms/{form id}/submission-email
@@ -147,9 +140,6 @@ sequenceDiagram
   admin-->>browser: 302
   browser->>admin: GET /forms/{form id}/email-code-sent
   admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   browser-->>user: show "Confirmation code sent" page
 
   inbox--)processor: read email
@@ -158,12 +148,10 @@ sequenceDiagram
   user->>browser: click "Enter the email address confirmation code" link
   browser->>admin: GET /forms/{form id}/confirm-submission-email
   admin->>api: GET /forms/{form id}
-  admin->>api: GET /forms/{form id}
   browser-->>user: show "Enter the confirmation code" page 
 
   user->>browser: enter code, click "Save and continue" button
   browser->>admin: POST /forms/{form id}/confirm-submission-email
-  admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}
   admin->>admin: check code
 
@@ -172,7 +160,6 @@ sequenceDiagram
     browser-->>user: show "Enter the confirmation code" page with error
     user->>browser: enter code, click "Save and continue" button
     browser->>admin: POST /forms/{form id}/confirm-submission-email
-  admin->>api: GET /forms/{form id}
     admin->>api: GET /forms/{form id}
     admin->>admin: check code
   end
@@ -181,7 +168,6 @@ sequenceDiagram
   api->>api: update form 
   admin-->>browser: 302
   browser->>admin: GET /forms/{form id}/submission-email-confirmed
-  admin->>api: GET /forms/{form id}
   admin->>api: GET /forms/{form id}
   browser-->>user: show "Email address confirmed" page
 ```

--- a/diagrams/sequence-diagrams/publishing-a-form.md
+++ b/diagrams/sequence-diagrams/publishing-a-form.md
@@ -16,12 +16,10 @@ sequenceDiagram
   user->>browser: Click "Make your form live" link
   browser->>admin: GET /forms/{form id}/make-live
   admin->>api: GET /api/v1/forms/{form id}
-  admin->>api: GET /api/v1/forms/{form id}
   browser-->>user: show "Make your form live" page
 
   user->>browser: Confirm making form live<br />click "Save and continue" button
   browser->>admin: POST /forms/{form id}/make-live
-  admin->>api: GET /api/v1/forms/{form id}
   admin->>api: GET /api/v1/forms/{form id}
   admin->>api: GET /api/v1/forms/{form id}/pages
   admin->>api: POST /api/v1/forms/{form id}/make-live<br>payload: {includes all form attributes and values}<br>Controller Action doesn't use any


### PR DESCRIPTION
https://github.com/alphagov/forms-admin/pull/370 removes extra request that forms-admin makes to forms-api to check if the users org owns the form being requested. Now forms-admin pulls in the form and then checks if user org owns it before displaying it.

https://trello.com/c/1ZIfDGz9/658-replace-forms-admin-check-form-belongs-to-users-org-with-a-pundit-permissions-policy