### PR TITLE
Add ADR for e2e tests moving to their own repo

### DIFF
--- a/ADR/ADR020-e2e-tests-get-own-repo.md
+++ b/ADR/ADR020-e2e-tests-get-own-repo.md
@@ -4,7 +4,7 @@ Date: 2023-07-14
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,16 +12,17 @@ We have a set of end to end tests which are currently located in the `forms-depl
 
 With the constant attention that the tests require, and the expansion of their coverage, it could be beneficial to separate them into their own github repository. This will make updating them; running them; and referring to them easier. 
 
+### Naming
+
+Based on other `alphagov` e2e repos, we could go with something like ***`forms-e2e-tests`*** for the repo name. This leaves plenty of room for other test formats i.e. `forms-smoke-tests`.
+
 ## Decision
 
-> what the team has decided to do
+We've decided to create a new repo for the e2e testsg
 
 ## Consequences
 
  - We have to (/get to) keep track of a new repo
  - Tests can be updated without requiring the `forms-deploy` repo to be in order
  - Test repo can have clearer dependencies and environment management
-- End to end tests can be public (forms-deploy repo is private)
-
-
-> both positive and negative consequences of the decision
+ - End to end tests can be public (forms-deploy repo is private)

--- a/ADR/ADR020-e2e-tests-get-own-repo.md
+++ b/ADR/ADR020-e2e-tests-get-own-repo.md
@@ -1,0 +1,26 @@
+# ADR020: Move the e2e tests into their own repo
+
+Date: 2023-07-14
+
+## Status
+
+Proposed
+
+## Context
+
+We have a set of end to end tests which are currently located in the `forms-deploy` repo [here](https://github.com/alphagov/forms-deploy/tree/main/capybara).
+
+With the constant attention that the tests require, and the expansion of their coverage, it could be beneficial to separate them into their own github repository. This will make updating them; running them; and referring to them easier. 
+
+## Decision
+
+> what the team has decided to do
+
+## Consequences
+
+ - We have to (/get to) keep track of a new repo
+ - Tests can be updated without requiring the `forms-deploy` repo to be in order
+ - Test repo can have clearer dependencies and environment management
+
+
+> both positive and negative consequences of the decision

--- a/ADR/ADR020-e2e-tests-get-own-repo.md
+++ b/ADR/ADR020-e2e-tests-get-own-repo.md
@@ -21,6 +21,7 @@ With the constant attention that the tests require, and the expansion of their c
  - We have to (/get to) keep track of a new repo
  - Tests can be updated without requiring the `forms-deploy` repo to be in order
  - Test repo can have clearer dependencies and environment management
+- End to end tests can be public (forms-deploy repo is private)
 
 
 > both positive and negative consequences of the decision


### PR DESCRIPTION
# What

Created an ADR discussing separating the e2e tests from `forms-deploy` and moving them into a new repo called `forms-e2e-tests` 
# How to review

1. Semantic: Do you agree with the changes?
2. Syntactic: Spelling, grammar, etc.

# Who can review
Anyone who's interested in the e2e tests!
