### PR TITLE
Replace org with organisation_id

### DIFF
--- a/diagrams/sequence-diagrams/creating-a-form.md
+++ b/diagrams/sequence-diagrams/creating-a-form.md
@@ -17,7 +17,7 @@ sequenceDiagram
   browser-->>user: show "What is the name of your form?" page
   user->>browser: Give the form a name<br />click "Save and continue" button
   browser->>admin: POST /forms/new<br />payload: forms_change_name_form%5Bname%5D={form name}
-  admin->>api: POST /forms<br />{"name":"{form name}",<br />"submission_email":"",<br />"org":"{user orginisation}"}
+  admin->>api: POST /forms<br />{"name":"{form name}",<br />"submission_email":"",<br />"organisation_id":{user organisation id}}
   api->>api: Create form
   api-->>admin: {"id":{form id}}
   admin-->>browser: 302


### PR DESCRIPTION
## What

Trello card: https://trello.com/c/pt9lphfe

We've changed our system to use organisation ID instead of organisation slug when communicating between the API and the admin app (see alphagov/forms-api#295). This commit updates our documentation to match.

## How to review

1. Syntactic: Spelling, grammar, etc.

## Who can review

Anyone