### PR TITLE
New diagram: "Accessing GOV.UK Forms via Auth0"

### DIFF
--- a/diagrams/sequence-diagrams/authentication.md
+++ b/diagrams/sequence-diagrams/authentication.md
@@ -66,3 +66,55 @@ sequenceDiagram
 
   browser-->>user: show GOV.UK Forms homepage
 ```
+
+## Accessing GOV.UK Forms via Auth0
+
+```mermaid
+sequenceDiagram
+    autonumber
+    title Accessing GOV.UK Forms via Auth0
+    actor user as unauthenticated user
+    participant browser as web browser
+    participant forms as GOV.UK Forms
+    participant auth0 as Auth0
+    participant ses as Amazon SES
+
+    user ->> browser: visit GOV.UK Forms
+    browser ->> forms: HTTP GET
+    forms ->> forms: no session cookie found
+    note right of forms: using Auth0 OmniAuth strategy
+    forms -->> browser: redirect to authenticate
+    browser ->> auth0: HTTP GET
+    auth0 -->> browser: login screen
+    browser -->> user: display login screen
+
+    user ->> browser: provide email address
+    browser ->> auth0: HTTP POST email address
+    auth0 ->> ses: use SES API
+    ses ->> user: send one time code by email
+    auth0 -->> browser: redirect to code entry screen
+    browser ->> auth0: HTTP GET
+    auth0 -->> browser: code entry screen
+    browser -->> user: display code entry screen
+
+    user ->> browser: provide one time code
+    browser ->> auth0: HTTP POST one time code
+    auth0 -->> browser: redirect to GOV.UK Forms with authorization code
+
+    browser ->> forms: HTTP GET with authorization code
+    forms ->> auth0: HTTP POST token request with authorization code
+    auth0 -->> forms: ID token
+    forms ->> forms: extract email address from ID token
+    alt First time user has accessed GOV.UK Forms
+        forms ->> forms: create record for user
+    else Returning user
+        forms ->> forms: get record of user
+    end
+    forms ->> forms: create user session
+    forms -->> browser: set session cookie
+    browser ->> browser: store session cookie
+    browser -->> user: display GOV.UK Forms
+
+    note right of user: user is now authenticated
+
+```


### PR DESCRIPTION
# PR Checklist

- [ ] If you are proposing a new decision record document, used the right template for that
      - ([ADR](https://github.com/alphagov/forms/blob/main/ADR/ADRXXX-architecture-decision-record-template.md), [decision-record](https://github.com/alphagov/forms/blob/main/decision-record/DRXXX-decision-record-template.md), engagement, [research](https://github.com/alphagov/forms/blob/main/research/YYYY-MM-DD-template.md))
- [x] Set yourself as the Assignee
- [x] Tag anyone you would like to review, or @forms-design or @forms-devs
- [x] Fill in the template below


---

# What

New sequence diagram to show how GOV.UK Forms interacts with Auth0.

# How to review

Does the diagram make sense? Is anything wrong, or missing?

# Who can review

Anyone can review.
