### PR TITLE
Update auth diagram with session timeout

### DIFF
--- a/diagrams/sequence-diagrams/authentication.md
+++ b/diagrams/sequence-diagrams/authentication.md
@@ -8,44 +8,53 @@ sequenceDiagram
     participant browser as web browser
     participant forms as GOV.UK Forms
     participant auth0 as Auth0
+    participant auth0-ui as Auth0 Universal Login
     participant ses as Amazon SES
 
     user ->> browser: visit GOV.UK Forms
     browser ->> forms: HTTP GET
-    forms ->> forms: no session cookie found
+    forms ->> forms: no _forms_admin_session cookie from client (or user id or auth_timestamp older than 24 hours)
     note right of forms: using Auth0 OmniAuth strategy
-    forms -->> browser: redirect to authenticate
+    forms -->> browser: redirect to /auth/auth0, set _forms_admin_session cookie
+    browser ->> forms: HTTP GET /auth/auth0
+    forms -->> browser: redirect to auth0-tenant/authorize
     browser ->> auth0: HTTP GET
-    auth0 -->> browser: login screen
+    auth0 -->> browser: redirect to Universal login
+    browser ->> auth0-ui: GET /u/login/
+    auth0-ui -->> browser: Login page
     browser -->> user: display login screen
 
     user ->> browser: provide email address
-    browser ->> auth0: HTTP POST email address
-    auth0 ->> ses: use SES API
+    browser ->> auth0-ui: HTTP POST email address
+    auth0-ui ->> ses: use SES API
     ses ->> user: send one time code by email
-    auth0 -->> browser: redirect to code entry screen
-    browser ->> auth0: HTTP GET
-    auth0 -->> browser: code entry screen
+    auth0-ui -->> browser: redirect to code entry screen
+    browser ->> auth0-ui: HTTP GET
+    auth0-ui -->> browser: code entry screen
     browser -->> user: display code entry screen
 
     user ->> browser: provide one time code
-    browser ->> auth0: HTTP POST one time code
+    browser ->> auth0-ui: HTTP POST one time code
+    auth0-ui -->> browser: redirect to auth0/authorize/resume
+    browser ->> auth0: GET /authorize/resume
     auth0 -->> browser: redirect to GOV.UK Forms with authorization code
 
     browser ->> forms: HTTP GET with authorization code
     forms ->> auth0: HTTP POST token request with authorization code
-    auth0 -->> forms: ID token
+    auth0 -->> forms: ID token, Access token
+    forms ->> auth0: Get JSON Web Key Set (JWKS) to verify tokens
+    auth0 -->> forms: Respond with JWK file
+    forms ->> forms: Verify tokens
     forms ->> forms: extract email address from ID token
     alt First time user has accessed GOV.UK Forms
         forms ->> forms: create record for user
     else Returning user
         forms ->> forms: get record of user
     end
-    forms ->> forms: create user session
-    forms -->> browser: set session cookie
-    browser ->> browser: store session cookie
+    forms -->> browser: redirect to original requested URL: '/', add user id and current time to _forms_admin_session cookie
+    browser ->> forms: Get '/'
+    forms -->> browser: Forms homepage HTML
     browser -->> user: display GOV.UK Forms
 
     note right of user: user is now authenticated
-
 ```

--- a/diagrams/sequence-diagrams/authentication.md
+++ b/diagrams/sequence-diagrams/authentication.md
@@ -8,51 +8,50 @@ sequenceDiagram
     participant browser as web browser
     participant forms as GOV.UK Forms
     participant auth0 as Auth0
-    participant auth0-ui as Auth0 Universal Login
     participant ses as Amazon SES
 
     user ->> browser: visit GOV.UK Forms
-    browser ->> forms: HTTP GET
-    forms ->> forms: no _forms_admin_session cookie from client (or user id or auth_timestamp older than 24 hours)
+    browser ->> forms: HTTP GET /
+    forms ->> forms: no _forms_admin_session cookie from client, cookie does not contain user_id or the auth_timestamp is older than 24 hours
     note right of forms: using Auth0 OmniAuth strategy
     forms -->> browser: redirect to /auth/auth0, set _forms_admin_session cookie
     browser ->> forms: HTTP GET /auth/auth0
-    forms -->> browser: redirect to auth0-tenant/authorize
-    browser ->> auth0: HTTP GET
+    forms -->> browser: redirect to /authorize
+    browser ->> auth0: HTTP GET /authorize
     auth0 -->> browser: redirect to Universal login
-    browser ->> auth0-ui: GET /u/login/
-    auth0-ui -->> browser: Login page
+    browser ->> auth0: GET /u/login/
+    auth0 -->> browser: Login page
     browser -->> user: display login screen
 
     user ->> browser: provide email address
-    browser ->> auth0-ui: HTTP POST email address
-    auth0-ui ->> ses: use SES API
+    browser ->> auth0: HTTP POST email address
+    auth0 ->> ses: use SES API
     ses ->> user: send one time code by email
-    auth0-ui -->> browser: redirect to code entry screen
-    browser ->> auth0-ui: HTTP GET
-    auth0-ui -->> browser: code entry screen
+    auth0 -->> browser: redirect to code entry screen
+    browser ->> auth0: HTTP GET
+    auth0 -->> browser: code entry screen
     browser -->> user: display code entry screen
 
     user ->> browser: provide one time code
-    browser ->> auth0-ui: HTTP POST one time code
-    auth0-ui -->> browser: redirect to auth0/authorize/resume
+    browser ->> auth0: HTTP POST one time code
+    auth0 -->> browser: redirect to auth0/authorize/resume
     browser ->> auth0: GET /authorize/resume
     auth0 -->> browser: redirect to GOV.UK Forms with authorization code
 
     browser ->> forms: HTTP GET with authorization code
     forms ->> auth0: HTTP POST token request with authorization code
     auth0 -->> forms: ID token, Access token
-    forms ->> auth0: Get JSON Web Key Set (JWKS) to verify tokens
+    forms ->> auth0: GET JSON Web Key Set (JWKS) to verify tokens
     auth0 -->> forms: Respond with JWK file
     forms ->> forms: Verify tokens
     forms ->> forms: extract email address from ID token
     alt First time user has accessed GOV.UK Forms
         forms ->> forms: create record for user
     else Returning user
-        forms ->> forms: get record of user
+        forms ->> forms: GET record of user
     end
     forms -->> browser: redirect to original requested URL: '/', add user id and current time to _forms_admin_session cookie
-    browser ->> forms: Get '/'
+    browser ->> forms: GET '/'
     forms -->> browser: Forms homepage HTML
     browser -->> user: display GOV.UK Forms
 


### PR DESCRIPTION
Trello: https://trello.com/c/PET8LyHH/1120-update-authentication-sequence-diagrams

I've made a few changes to this diagram to try and make it clearer what's happening. I'm happy to revert/change any of them if it's not helping.

In this PR, I've:

- Added the missing redirect to forms admin/auth/auth0.

- Split Auth0 into two actors to reflect the different roles it's playing in our system.
Originally this was to show the difference between our login session and the [auth0 session](https://auth0.com/docs/manage-users/sessions/session-layers).

  [It turns out this doesn't need to be documented
yet](https://trello.com/c/rmk3P0kO/1299-fix-auth0-single-sign-on), but I think it still might be useful. It would be good to compare with the google workspace diagram.

  It could be that auth0 is outside our control so we should treat it as a black box.

- Changed the references to session to be more precise about what's happening. Talking in terms of the cookie values is lower level but gives [this ticket](https://trello.com/c/yi3v9Mgo/1121-require-forms-admin-users-to-re-authenticate-after-24-hours) a clearer description.

  Session is the right term but it is also implies more is happening behind the scenes, which I don't think there is here.
