### PR TITLE
Add link to drafted content for question previews

### DIFF
--- a/design/features/previewing-a-question/version-1.md
+++ b/design/features/previewing-a-question/version-1.md
@@ -152,7 +152,7 @@ Under the box is a green primary call to action “Add a new question”. Below 
 
 ## Notes
 
-- The content for answer types explanation text is still required for the preview question page  
+- The content for answer types explanation text was not drafted when this functionality was first added to the prototype. It has now been drafted, but not yet added to the prototype. [Members of the Forms team can see the drafts of this content here](https://docs.google.com/document/d/1QlzCLyoBq0UGqbekcsfnRZEAcZtmlEOUqBN_kYPltHc/edit?pli=1#heading=h.oy48b59szv9o). 
 
 ___
 


### PR DESCRIPTION
# What
I've added a link to a document of content for previewing a question for each different answer type. This is just a temporary measure for now - until the content is updated in the prototype when we can document it properly.

# How to review
1. check the link works. 
2. check Hannah hasn't made any typos or errors. 
3. tell Hannah if you think this is a terrible thing to do. 

# Who can review
Anyone. Only needs one review.
