### PR TITLE
Add ADR to remove Papertrail

### DIFF
--- a/ADR/ADR013-use-paper-trail-gem-for-auditing-and-record-backups.md
+++ b/ADR/ADR013-use-paper-trail-gem-for-auditing-and-record-backups.md
@@ -4,7 +4,7 @@ Date: 2023-02-27
 
 ## Status
 
-Accepted
+Superseded by ADR025
 
 ## Context
 
@@ -12,12 +12,12 @@ We need way to audit changes to database records to identify what has changed an
 will be surfaced to users later on when we come to versioning. This is still valuable to record now for any support tickets
 that come in and require us to understand the form/pages history.
 
-There is also a secondary benefit where it could be possible to restore individual records rather than having to restore 
+There is also a secondary benefit where it could be possible to restore individual records rather than having to restore
 from database backups.
 
 ## Decision
 
-Add [PaperTrail](https://github.com/paper-trail-gem/paper_trail) as part of draft/live work so we can start recording 
+Add [PaperTrail](https://github.com/paper-trail-gem/paper_trail) as part of draft/live work so we can start recording
 changes to Forms/Pages but also from any other tables we might want to monitor.
 
 ## Consequences
@@ -26,11 +26,11 @@ We will be able to identify very easily what attribute on a specific model chang
 This means that we do not have to trawl splunk server logs trying to see what information had been sent to the server
 and at what point did the model get updated to. We also need this information to surface back to the user.
 
-By setting it up now, we can double check the data that's being collected and tweak it before surfacing it to our users. 
+By setting it up now, we can double check the data that's being collected and tweak it before surfacing it to our users.
 If there are any issues we can reconfig or completely drop and restart this data collection without any questions from our users.
 
-We already know that we will need to do some additional work to identify who made the changes as we don't record that now as 
-forms-api does not have this data. We will need to pass it in from forms-admin. If we do setup PaperTrail now, when we 
+We already know that we will need to do some additional work to identify who made the changes as we don't record that now as
+forms-api does not have this data. We will need to pass it in from forms-admin. If we do setup PaperTrail now, when we
 come to do User Management, we can set up the extra details as part of that work.
 
 ### Positives
@@ -42,13 +42,13 @@ come to do User Management, we can set up the extra details as part of that work
 - PaperTrail also accepts custom events an can be manually triggered
 - It's really easy to tell PaperTrail to track a model by including `has :papertrail` to the model that you would like to
   track. There are also additional configuration options to control if/when to log changes.
-- PaperTrail is very customisable and used a lot within the Rails community for auditing/tracking 
+- PaperTrail is very customisable and used a lot within the Rails community for auditing/tracking
 - When we come to versioning and surfacing versions to our users we will already have some details to display
 
 ### Negatives
-- Currently we don't have a means of passing users details between forms-admin and forms-runner. So we will not be able 
-  to record users details straight away but we can look at configuring Papertrail to include these details as part of 
+- Currently we don't have a means of passing users details between forms-admin and forms-runner. So we will not be able
+  to record users details straight away but we can look at configuring Papertrail to include these details as part of
   User Management work we have planned in the future
-- Difficult to link associations records together but if we record both Form/Pages, we should at least be able to restore 
+- Difficult to link associations records together but if we record both Form/Pages, we should at least be able to restore
   specific versions of each one if a support ticket comes in.
 

--- a/ADR/ADR025-remove-papertrail.md
+++ b/ADR/ADR025-remove-papertrail.md
@@ -1,0 +1,24 @@
+# ADR025: Decision Record Title (a description of the decision, not the problem)
+
+Date: 2024-02-01
+
+## Status
+
+> Accepted or Rejected
+
+## Context
+
+Previously we added [PaperTrail](ADR013-use-paper-trail-gem-for-auditing-and-record-backups.md) with the intention to support reinstating from previous versions. We are not using it for that at all and we are not certain we're using it for the right models. Note that the previous ADR was added over a year ago.
+
+Until we have a need for versioning, we should remove it from our code base to reduce complexity and code rot. We can easily re-add Papertrail when we get to implementing versioning.
+
+## Decision
+
+Remove Papertrail and clean up our code and database.
+
+## Consequences
+We will not be able to use PaperTrail to change a form from the `live_with_draft` state to the `live` state.
+
+We will not be able to use PaperTrail for audit purposes.
+
+We will need to implement a different way of determining if a user has been upgraded from a trial account to a full account. We currently check versions of a user and display a banner to them on their next login.

--- a/ADR/ADR025-remove-papertrail.md
+++ b/ADR/ADR025-remove-papertrail.md
@@ -4,7 +4,7 @@ Date: 2024-02-01
 
 ## Status
 
-> Accepted or Rejected
+> Accepted
 
 ## Context
 


### PR DESCRIPTION
# PR Checklist

- [ ] If you are proposing a new decision record document, used the right template for that
      - ([ADR](https://github.com/alphagov/forms/blob/main/ADR/ADRXXX-architecture-decision-record-template.md), [decision-record](https://github.com/alphagov/forms/blob/main/decision-record/DRXXX-decision-record-template.md), engagement, [research](https://github.com/alphagov/forms/blob/main/research/YYYY-MM-DD-template.md))
- [ ] Set yourself as the Assignee
- [ ] Tag anyone you would like to review, or @forms-design or @forms-devs
- [ ] Fill in the template below


---

# What

Let's remove Papertrail. We added it a year ago and are not using it for versioning. We can add it back in when we want to do versioning and are using it for that purpose.

# How to review

Describe the steps required to test the changes.

For example:

1. Semantic: Do you agree with the changes?
1. Syntactic: Spelling, grammar, etc.

# Who can review

@alphagov/forms-devs 