### PR TITLE
Add GitHub discussion template for RFCs

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/rfcs.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs.yml
@@ -1,0 +1,23 @@
+title: "[RFC]"
+labels: "[rfc]"
+body:
+  - type: markdown
+    id: rfc
+    validations:
+      required: true
+    attributes:
+      value: |
+
+        # My RFC Title
+
+        ## Summary
+
+        An abstract, tl;dr or executive summary of your RFC.
+
+        ## Problem
+
+        Describe the problem your RFC is trying to solve.
+
+        ## Proposal
+
+        Describe your proposal, with a focus on clarity of meaning. You MAY use [RFC2119-style](https://www.ietf.org/rfc/rfc2119.txt) MUST, SHOULD and MAY language to help clarify your intentions.


### PR DESCRIPTION
# PR Checklist

- [ ] If you are proposing a new decision record document, used the right template for that
      - ([ADR](https://github.com/alphagov/forms/blob/main/ADR/ADRXXX-architecture-decision-record-template.md), [decision-record](https://github.com/alphagov/forms/blob/main/decision-record/DRXXX-decision-record-template.md), engagement, [research](https://github.com/alphagov/forms/blob/main/research/YYYY-MM-DD-template.md))
- [x] Set yourself as the Assignee
- [ ] Tag anyone you would like to review, or @forms-design or @forms-devs
- [x] Fill in the template below


---

# What

We've decided to make better use of GitHub's Discussion feature and also to start making RFCs. This adds a template for us to make RFCs in GitHub Discussions/

# How to review

Spelling, grammar, syntax against https://docs.github.com/en/discussions/managing-discussions-for-your-community/syntax-for-discussion-category-forms 

# Who can review

@alphagov/forms-devs 