### PR TITLE
Add licenses

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GOV.UK Forms
 
-We record our work and decisions in this repo. 
+We record our work and decisions in this repo.
 
-You can find: 
+You can find:
 
 - product decisions in [decision-record/](decision-record/)
 - technical decisions in [ADR/](ADR)
@@ -10,7 +10,7 @@ You can find:
 - user research findings in [research/](research/)
 - documentation of our designs in [design/](design/)
 
-We also have: 
+We also have:
 - [a private wiki](https://github.com/alphagov/forms-team/wiki) for team documentation (set-up, onboarding etc)
 - [a public wiki](https://github.com/alphagov/forms/wiki) that we don't use all that much
 
@@ -22,3 +22,9 @@ You can find our code in the following repositories:
 - [forms-product-page](https://github.com/alphagov/forms-product-page) - our product pages, as seen at [https://forms.service.gov.uk](https://forms.service.gov.uk)
 - [forms-prototypes](https://github.com/alphagov/forms-prototypes) - our prototypes, used for user research and design exploration.
 - [govuk-forms-markdown](https://github.com/alphagov/govuk-forms-markdown) - our gem for rendering the limited subset of markdown we support.
+
+## License
+
+Unless stated otherwise, the codebase is released under [the MIT License](LICENCE). This covers both the codebase and any sample code in the documentation.
+
+The documentation is [© Crown copyright](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/) and available under the terms of the [Open Government 3.0 licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).


### PR DESCRIPTION

# What

Adding a missing LICENSE file. Also add link to the Open Government License.

Fixes https://github.com/alphagov/forms/issues/182