### PR TITLE
Remove outdated state diagram

### DIFF
--- a/diagrams/form-states-and-events.md
+++ b/diagrams/form-states-and-events.md
@@ -1,24 +1,6 @@
 # Form states and events used by state machine
 
-## Current Flow
-
-```mermaid
----
- title: Form states and events called to transition to state
----
-stateDiagram-v2
-    Draft --> Live : make_live!
-    Draft --> Deleted : delete_form!
-    live_with_draft: Live with draft
-    Live --> live_with_draft : create_draft_from_live_form!
-    live_with_draft --> Live : make_live!
-    live_with_draft --> Draft: archive_live_form!
-    Live --> Draft: archive_live_form!
-   
-```
-
-
-## Future Flow
+## State diagram
 
 ```mermaid
 ---


### PR DESCRIPTION
# PR Checklist

- [x] Set yourself as the Assignee
- [x] Tag anyone you would like to review, or @forms-design or @forms-devs
- [x] Fill in the template below

---

# What

The state machine in the "Future Flow" state diagram has been the current system for some time now. This commit removes the "Current Flow" state diagram as it is outdated.

# How to review

Describe the steps required to test the changes.

For example:

1. Semantic: Do you agree with the changes?
1. Syntactic: Spelling, grammar, etc.

# Who can review

Any devs.