### PR TITLE
Update github team names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 - [ ] If you are proposing a new decision record document, used the right template for that
       - ([ADR](https://github.com/govuk-forms/forms/blob/main/ADR/ADRXXX-architecture-decision-record-template.md), [decision-record](https://github.com/govuk-forms/forms/blob/main/decision-record/DRXXX-decision-record-template.md), engagement, [research](https://github.com/govuk-forms/forms/blob/main/research/YYYY-MM-DD-template.md))
 - [ ] Set yourself as the Assignee
-- [ ] Tag anyone you would like to review, or @forms-design or @forms-devs
+- [ ] Tag anyone you would like to review, or govuk-forms/govuk-forms-design or govuk-forms/govuk-forms-devs
 - [ ] Fill in the template below
 
 


### PR DESCRIPTION

# What
Update github team names in the pr template

We changed these when we moved to our own GitHub org to match the requirements from Engineering Enablement


